### PR TITLE
Enforce node version required by the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
     "typescript": "^5"
+  },
+  "engines": {
+    "node": "^18.0.0"
   }
 }


### PR DESCRIPTION
Otherwise, I spent half an hour trying to figure out what running `npm run dev` fails